### PR TITLE
[roundup] Upgrade dependencies

### DIFF
--- a/roundup/package.json
+++ b/roundup/package.json
@@ -10,12 +10,13 @@
     "test:unit": "vitest --run"
   },
   "dependencies": {
-    "@devvit/public-api-next": "^0.9.10-next-2023-06-09-58259c73e.0",
+    "@devvit/public-api": "0.10.1",
     "date-fns-tz": "^2.0.0",
+    "date-fns": "^2.0.0",
     "timezones-list": "^3.0.2"
   },
   "devDependencies": {
-    "@devvit/tsconfig": "0.9.10-next-2023-06-05-de21ed869.0",
+    "@devvit/tsconfig": "0.10.1",
     "typescript": "4.9.3",
     "vitest": "0.31.1"
   }

--- a/roundup/src/main.ts
+++ b/roundup/src/main.ts
@@ -9,7 +9,7 @@ import {
     zonedTimeToUtc,
 } from 'date-fns-tz'
 
-import { Devvit, SettingsValues, Context, RichTextBuilder, Post } from '@devvit/public-api-next';
+import { Devvit, SettingsValues, Context, RichTextBuilder, Post } from '@devvit/public-api';
 
 import {
     SCHEDULER_JOB_SETTINGS_CHECKER,

--- a/roundup/yarn.lock
+++ b/roundup/yarn.lock
@@ -2,70 +2,78 @@
 # yarn lockfile v1
 
 
-"@devvit/plugins@0.9.10-next-2023-06-09-58259c73e.0":
-  version "0.9.10-next-2023-06-09-58259c73e.0"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/plugins/-/@devvit/plugins-0.9.10-next-2023-06-09-58259c73e.0.tgz"
-  integrity sha512-+IdDqhfPoA5l+ypmk9QNUiNjyczJ+qcjYI9WgpM3vSrWQRDTiJ5zuGgkA4HXWNjJIHvgJqzhtAyj6LwVE+Zu/g==
+"@babel/runtime@^7.21.0":
+  version "7.22.6"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@babel/runtime/-/runtime-7.22.6.tgz#57d64b9ae3cff1d67eb067ae117dac087f5bd438"
+  integrity sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==
   dependencies:
-    "@devvit/protos" "0.9.10-next-2023-06-09-58259c73e.0"
+    regenerator-runtime "^0.13.11"
 
-"@devvit/protos@0.9.10-next-2023-06-09-58259c73e.0":
-  version "0.9.10-next-2023-06-09-58259c73e.0"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/protos/-/@devvit/protos-0.9.10-next-2023-06-09-58259c73e.0.tgz"
-  integrity sha512-PoYHVXt31rX8kfaAa+BS2jOVHuBi7MIixSq8v1oLnS2ikx75yvlSp9Ftsw+5U3sDWkBfLNwTmuxbXal0ag+wew==
+"@devvit/plugins@0.10.1":
+  version "0.10.1"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/plugins/-/@devvit/plugins-0.10.1.tgz#ab12d8948a6c943c9143150e3443b21ec078f577"
+  integrity sha512-AYlVBN9Yq+oW220Q0VRUGp/F+yB816TGrCoxQDgNoCbEw6dugEDuWbaSZ7Erm8s5NZORzz3cROBhJCkvOhholA==
+  dependencies:
+    "@devvit/protos" "0.10.1"
+
+"@devvit/protos@0.10.1":
+  version "0.10.1"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/protos/-/@devvit/protos-0.10.1.tgz#54f40c64a8f8b1a321e422edded87b48a3e3013d"
+  integrity sha512-GOb2t2GfSdEFeGJdiabzpt/Uwzwm8EcgGYSm9AxtsvLYJEF0vm/nGlpBmTVwZ+jndnYeEdl0L5LisKOxUy6snw==
   dependencies:
     glob "8.0.3"
-    protobufjs "7.1.2"
+    protobufjs "7.2.4"
     rxjs "7.5.7"
 
-"@devvit/public-api-next@^0.9.10-next-2023-06-09-58259c73e.0":
-  version "0.9.10-next-2023-06-09-58259c73e.0"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/public-api-next/-/@devvit/public-api-next-0.9.10-next-2023-06-09-58259c73e.0.tgz"
-  integrity sha512-ZmxXeqEvF/QL7fF5yZhZzjoIF4h/xxZ6dVuY++Vsu9lTw8MGak8/vxLvoKNfiYfsMFwCdwlCdt42SD2h68T1yg==
+"@devvit/public-api@0.10.1":
+  version "0.10.1"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/public-api/-/@devvit/public-api-0.10.1.tgz#54604f513a964fc8de575eeee5d5d7be27afac29"
+  integrity sha512-Seu7CuPfjwzFZ99tPkDsehHmo3iNQ9SjAvWZfdHA/0YdUFUFQoroCAiosk4sUimMiA/Imfwpd+0UalkBZSpgmg==
   dependencies:
-    "@devvit/protos" "0.9.10-next-2023-06-09-58259c73e.0"
-    "@devvit/runtimes" "0.9.10-next-2023-06-09-58259c73e.0"
-    "@devvit/shared-types" "0.9.10-next-2023-06-09-58259c73e.0"
+    "@devvit/protos" "0.10.1"
+    "@devvit/runtimes" "0.10.1"
+    "@devvit/shared-types" "0.10.1"
     base64-js "1.5.1"
     clone-deep "4.0.1"
     lodash.isequal "4.5.0"
 
-"@devvit/runtimes@0.9.10-next-2023-06-09-58259c73e.0":
-  version "0.9.10-next-2023-06-09-58259c73e.0"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/runtimes/-/@devvit/runtimes-0.9.10-next-2023-06-09-58259c73e.0.tgz"
-  integrity sha512-PzQjkZIiNWvscPl0lV6D/gH08XpLJZa2OswN5uYfvX9H745k92jYtFlIPXsH8T74+nUKC1HHCvzZXG9PGw4eJA==
+"@devvit/runtimes@0.10.1":
+  version "0.10.1"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/runtimes/-/@devvit/runtimes-0.10.1.tgz#aa412898dc0fd98beb6ba1717d8466cb727d0cb0"
+  integrity sha512-hkBYE/IIKAlZnMPxri5g4voESnt+7HL9ELTqGaJPOD47miWqjzUWx+gvVo72wHvy38CGr5oXYFTGGbMNxMJ4WQ==
   dependencies:
-    "@devvit/plugins" "0.9.10-next-2023-06-09-58259c73e.0"
-    "@devvit/protos" "0.9.10-next-2023-06-09-58259c73e.0"
-    "@devvit/shared-types" "0.9.10-next-2023-06-09-58259c73e.0"
-    "@devvit/web-worker" "0.9.10-next-2023-06-09-58259c73e.0"
+    "@devvit/plugins" "0.10.1"
+    "@devvit/protos" "0.10.1"
+    "@devvit/shared-types" "0.10.1"
+    "@devvit/web-worker" "0.10.1"
     base64-js "1.5.1"
     buffer "6.0.3"
     cron-parser "4.7.1"
     grpc-web "1.4.2"
     lru-cache "7.10.1"
     node-localstorage "2.2.1"
+    redis "4.6.6"
     rxjs "7.5.7"
     undici "5.21.2"
     uuid "9.0.0"
     ws "8.11.0"
 
-"@devvit/shared-types@0.9.10-next-2023-06-09-58259c73e.0":
-  version "0.9.10-next-2023-06-09-58259c73e.0"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/shared-types/-/@devvit/shared-types-0.9.10-next-2023-06-09-58259c73e.0.tgz"
-  integrity sha512-5nZ8Sz0a/EBQlezC83yHT2+BktK4gUKvr1s3NskZcMKrXznxA8ik7tof8SLm+EpWAO2beBaeWJpvF1h80O8gEQ==
+"@devvit/shared-types@0.10.1":
+  version "0.10.1"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/shared-types/-/@devvit/shared-types-0.10.1.tgz#e0b8e464dbc1f70f95bd58aefed86004a3868b7e"
+  integrity sha512-OywPVgPO0ZKrVH4t2zNX6Bq9YSehayKLEoXkP3rbspWzWnQ4AuYfCGXGfDebVV7TUm3taYcgXEXupG9kjjQTXA==
   dependencies:
-    "@devvit/protos" "0.9.10-next-2023-06-09-58259c73e.0"
+    "@devvit/protos" "0.10.1"
 
-"@devvit/tsconfig@0.9.10-next-2023-06-05-de21ed869.0":
-  version "0.9.10-next-2023-06-05-de21ed869.0"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/tsconfig/-/@devvit/tsconfig-0.9.10-next-2023-06-05-de21ed869.0.tgz"
-  integrity sha512-gREOK/hzMLa8blAqW8kL+3TkfPVudiK2M9o+Ua03iSicTeYef91qQku0Mxi8k4/qmRJMUGCgoKeF2Ib5hJRWjg==
+"@devvit/tsconfig@0.10.1":
+  version "0.10.1"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/tsconfig/-/@devvit/tsconfig-0.10.1.tgz#b5d7aceec62d771ca29fb37f82109290123031f3"
+  integrity sha512-WHlFHmnbKL7H2IwgsbrLxyQ4HPXusAeXFymruuvDX3ZAJH5+fjVbFo9U4EynWf8Mex2HJE47rU6Z9dhIfL7tOQ==
 
-"@devvit/web-worker@0.9.10-next-2023-06-09-58259c73e.0":
-  version "0.9.10-next-2023-06-09-58259c73e.0"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/web-worker/-/@devvit/web-worker-0.9.10-next-2023-06-09-58259c73e.0.tgz"
-  integrity sha512-d5Yw4rkpnNj29iWeUNeW2Ri1zIzGS2lMAq6ZR1LQRpegz29URJ3bOJSF2loLdqtqXfWBRjz2grKeUHWPPPMImw==
+"@devvit/web-worker@0.10.1":
+  version "0.10.1"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@devvit/web-worker/-/@devvit/web-worker-0.10.1.tgz#2a757ef520b726af71457a8328227c15c2979911"
+  integrity sha512-hM0QhVchVFaczl/B/QuqLmO/10v0XC8l3kkb4tIoVs8w/IcZ2CvzySqGMQJBDOOE3sxJgTWWGlJluos9D8QCXg==
 
 "@esbuild/android-arm64@0.17.19":
   version "0.17.19"
@@ -235,6 +243,40 @@
   resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
+"@redis/bloom@1.2.0":
+  version "1.2.0"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@redis/bloom/-/bloom-1.2.0.tgz#d3fd6d3c0af3ef92f26767b56414a370c7b63b71"
+  integrity sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==
+
+"@redis/client@1.5.7":
+  version "1.5.7"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@redis/client/-/client-1.5.7.tgz#92cc5c98c76f189e37d24f0e1e17e104c6af17d4"
+  integrity sha512-gaOBOuJPjK5fGtxSseaKgSvjiZXQCdLlGg9WYQst+/GRUjmXaiB5kVkeQMRtPc7Q2t93XZcJfBMSwzs/XS9UZw==
+  dependencies:
+    cluster-key-slot "1.1.2"
+    generic-pool "3.9.0"
+    yallist "4.0.0"
+
+"@redis/graph@1.1.0":
+  version "1.1.0"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@redis/graph/-/graph-1.1.0.tgz#cc2b82e5141a29ada2cce7d267a6b74baa6dd519"
+  integrity sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==
+
+"@redis/json@1.0.4":
+  version "1.0.4"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@redis/json/-/json-1.0.4.tgz#f372b5f93324e6ffb7f16aadcbcb4e5c3d39bda1"
+  integrity sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==
+
+"@redis/search@1.1.2":
+  version "1.1.2"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@redis/search/-/search-1.1.2.tgz#6a8f66ba90812d39c2457420f859ce8fbd8f3838"
+  integrity sha512-/cMfstG/fOh/SsE+4/BQGeuH/JJloeWuH+qJzM8dbxuWvdWibWAOAHHCZTMPhV3xIlH4/cUEIA8OV5QnYpaVoA==
+
+"@redis/time-series@1.0.4":
+  version "1.0.4"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@redis/time-series/-/time-series-1.0.4.tgz#af85eb080f6934580e4d3b58046026b6c2b18717"
+  integrity sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==
+
 "@types/chai-subset@^1.3.3":
   version "1.3.3"
   resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/@types/chai-subset/-/chai-subset-1.3.3.tgz"
@@ -390,6 +432,11 @@ clone-deep@4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+cluster-key-slot@1.1.2:
+  version "1.1.2"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
+
 concordance@^5.0.4:
   version "5.0.4"
   resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/concordance/-/concordance-5.0.4.tgz"
@@ -415,6 +462,13 @@ date-fns-tz@^2.0.0:
   version "2.0.0"
   resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/date-fns-tz/-/date-fns-tz-2.0.0.tgz#1b14c386cb8bc16fc56fe333d4fc34ae1d1099d5"
   integrity sha512-OAtcLdB9vxSXTWHdT8b398ARImVwQMyjfYGkKD2zaGpHseG2UPHbHjXELReErZFxWdSLph3c2zOaaTyHfOhERQ==
+
+date-fns@^2.0.0:
+  version "2.30.0"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/date-fns/-/date-fns-2.30.0.tgz#f367e644839ff57894ec6ac480de40cae4b0f4d0"
+  integrity sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==
+  dependencies:
+    "@babel/runtime" "^7.21.0"
 
 date-time@^3.1.0:
   version "3.1.0"
@@ -484,6 +538,11 @@ fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+generic-pool@3.9.0:
+  version "3.9.0"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/generic-pool/-/generic-pool-3.9.0.tgz#36f4a678e963f4fdb8707eab050823abc4e8f5e4"
+  integrity sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==
 
 get-func-name@^2.0.0:
   version "2.0.0"
@@ -709,10 +768,10 @@ pretty-format@^27.5.1:
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
-protobufjs@7.1.2:
-  version "7.1.2"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/protobufjs/-/protobufjs-7.1.2.tgz"
-  integrity sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==
+protobufjs@7.2.4:
+  version "7.2.4"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/protobufjs/-/protobufjs-7.2.4.tgz#3fc1ec0cdc89dd91aef9ba6037ba07408485c3ae"
+  integrity sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -731,6 +790,23 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+redis@4.6.6:
+  version "4.6.6"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/redis/-/redis-4.6.6.tgz#46d4f2d149d1634d6ef53db5747412a0ef7974ec"
+  integrity sha512-aLs2fuBFV/VJ28oLBqYykfnhGGkFxvx0HdCEBYdJ99FFbSEMZ7c1nVKwR6ZRv+7bb7JnC0mmCzaqu8frgOYhpA==
+  dependencies:
+    "@redis/bloom" "1.2.0"
+    "@redis/client" "1.5.7"
+    "@redis/graph" "1.1.0"
+    "@redis/json" "1.0.4"
+    "@redis/search" "1.1.2"
+    "@redis/time-series" "1.0.4"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 rollup@^3.21.0:
   version "3.23.1"
@@ -940,9 +1016,9 @@ ws@8.11.0:
   resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/ws/-/ws-8.11.0.tgz"
   integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
 
-yallist@^4.0.0:
+yallist@4.0.0, yallist@^4.0.0:
   version "4.0.0"
-  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/yallist/-/yallist-4.0.0.tgz"
+  resolved "https://artifactory.build.ue1.snooguts.net:443/artifactory/api/npm/reddit-npm-prod/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yocto-queue@^1.0.0:


### PR DESCRIPTION
- Upgrade Devvit dependencies to the latest and greatest per CLI recommendation.
- Flip deprecated public-api-next to replacement public-next.
- Add missed date-fns dependency.